### PR TITLE
Fix rspec deprecation warning

### DIFF
--- a/spec/lens/sender_spec.rb
+++ b/spec/lens/sender_spec.rb
@@ -6,8 +6,7 @@ describe Lens::Sender do
   let(:http) { stub_http }
 
   it "makes a single request when sending notices" do
-    http.should_receive(:post).once
+    expect(http).to receive(:post).once
     Lens.sender.send_to_lens('abc123')
   end
-
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,7 @@
 module Helpers
   def stub_http(options = {})
     response = options[:response] || Net::HTTPSuccess.new('1.2', '200', 'OK')
-    response.stub(:body => options[:body] || '{"id":"1234"}')
+    allow(response).to receive(:body).with(options[:body] || '{"id":"1234"}')
     http = double(
       :post          => response,
       :read_timeout= => nil,
@@ -10,7 +10,7 @@ module Helpers
       :verify_mode=  => nil,
       :use_ssl=      => nil
     )
-    Net::HTTP.stub(:new).and_return(http)
+    allow(Net::HTTP).to receive(:new).and_return(http)
     http
   end
 


### PR DESCRIPTION
replace stub with allow
replace should with expect