### PR TITLE
change rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
+    - "spec/*_helper.rb"
+    - "bin/*"
   UseCache: false
 Style/CollectionMethods:
   Description: Preferred collection methods.
@@ -17,7 +19,7 @@ Style/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
   SupportedStyles:
   - leading
   - trailing
@@ -29,12 +31,12 @@ Style/FileName:
 Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
-  Enabled: false
-  MinBodyLength: 1
+  Enabled: true
+  MinBodyLength: 5
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
-  Enabled: false
+  Enabled: true
   MaxLineLength: 100
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
@@ -96,7 +98,7 @@ Style/SingleLineBlockParams:
 Style/SingleLineMethods:
   Description: Avoid single-line methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
-  Enabled: false
+  Enabled: true
   AllowIfMethodIsEmpty: true
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
@@ -117,11 +119,13 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingComma:
   Description: Checks for trailing comma in parameter lists and literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
-  Enabled: false
+  Enabled: true
   EnforcedStyleForMultiline: no_comma
   SupportedStyles:
   - comma
   - no_comma
+Metrics/LineLength:
+  Max: 100
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
@@ -145,13 +149,13 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Description: Avoid methods longer than 10 lines of code.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
-  Enabled: false
+  Enabled: true
   CountComments: false
-  Max: 10
+  Max: 20
 Metrics/ParameterLists:
   Description: Avoid parameter lists longer than three or four parameters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
-  Enabled: false
+  Enabled: true
   Max: 5
   CountKeywordArgs: true
 Metrics/PerceivedComplexity:
@@ -169,7 +173,7 @@ Style/InlineComment:
   Enabled: false
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
-  Enabled: false
+  Enabled: true
 Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
@@ -224,7 +228,7 @@ Lint/EachWithObjectArgument:
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
+  Enabled: true
 Lint/LiteralInCondition:
   Description: Checks of literals used in conditions.
   Enabled: false


### PR DESCRIPTION
add excluded files
enforce dot style to leading
enable checking for guard clause
avoid single line methods
enable trailing comma checking
set max line length to 100
set max method length to 20 lines
set max params number to 5
check for get_/set_ method naming
check for hidden exceptions